### PR TITLE
Nvda 2021.1 compatibility

### DIFF
--- a/addon/doc/pt_BR/readme.md
+++ b/addon/doc/pt_BR/readme.md
@@ -20,4 +20,10 @@ A utilização deste complemento é simples, basta seguir os seguintes passos:
 
 No caso de encontrar um bug, pode mencionar no Twitter em [HamadaTrichine](https://twitter.com/hamadatrichine), ou ou enviar-me um [email.](mailto:hamadalog25@gmail.com)
 
+## Colaboradores
+
+Aqui está a a lista de todos os colaboradores:
+
+* Marlon Sousa (Correções ortográficas, traduções, compatibilidade com NVDA 2019.3 e 2021.1)
+
 [1]: http://hamadatr.servegame.com/nvdaAddons

--- a/addon/doc/pt_PT/readme.md
+++ b/addon/doc/pt_PT/readme.md
@@ -20,4 +20,10 @@ A utilização deste extra é simples, basta seguir os seguintes passos:
 
 No caso de encontrar um bug, pode mencionar no Twitter em [HamadaTrichine](https://twitter.com/hamadatrichine), ou ou enviar-me um [email.](mailto:hamadalog25@gmail.com)
 
+## Colaboradores
+
+Aqui está a a lista de todos os colaboradores:
+
+* Marlon Sousa (Correções ortográficas, traduções, compatibilidade com NVDA 2019.3 e 2021.1)
+
 [1]: http://hamadatr.servegame.com/nvdaAddons

--- a/buildVars.py
+++ b/buildVars.py
@@ -21,15 +21,15 @@ addon_info = {
 	When you press quick navigation keys such as h, b, f and others, you will be placed on the next element regardless of your current position on a webpage.
 	If elements are not found below your position, you will be placed at the first element of the requested type available from the beginning of the page and virseversa when you are searching upwards."""),
 	# version
-	"addon_version" : "1.5",
+	"addon_version" : "1.6",
 	# Author(s)
 	"addon_author" : u"Hamada Trichine <hamadalog25@gmail.com>",
 	# URL for the add-on documentation support
 	"addon_url" : "https://github.com/hamadatrichine/nvda-screen-wrapping",
 	# Documentation file name
 	"addon_docFileName" : "readme.html",
-	"addon_nvdaMinimumVersion" : "2019.3",
-	"addon_lastTestedNvdaVersion" : "2020.4",
+	"addon_nvdaMinimumVersion" : "2021.1",
+	"addon_lastTestedNvdaVersion" : "2021.1",
 	"addon_updateChannel" : None,
 }
 

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,6 @@ In the case of any bugs you can mention me on twitter [at HamadaTrichine](https:
 
 Here is the list of all contributors:
 
-* Marlon Sousa (spelling, translations, port to NVDA 2019.3 compatibility)
+* Marlon Sousa (spelling, translations, NVDA 2019.3 and 2021.1 compatibility)
 
 [1]: https://github.com/hamadatrichine/nvda-screen-wrapping/releases/latest


### PR DESCRIPTION
In this pull request we generate a new version compatible with NVDA 2021.1.

We also make some documentation updates.

Testing ad code inspection has shown that the addon was already compatible, so we just changed manifest to declare that and thus make the addon installable in NVDA 2021.1 and latter versions.