### PR TITLE
feature/nvda 2023.1 compatibility

### DIFF
--- a/addon/doc/pt_BR/readme.md
+++ b/addon/doc/pt_BR/readme.md
@@ -12,7 +12,8 @@ Se estivermos a usar as teclas de navegação rápida no sentido inverso, ou sej
 A utilização deste complemento é simples, basta seguir os seguintes passos:
 
  1. Instale o complemento;
- 2. Navegue pelas páginas Web, usando  as teclas de navegação rápida;
+ 2. Navegue pelas páginas Web, usando  as teclas de navegação rápida, ou tente realizar uma busca usando NVDA+CTRL+F (comando padrão);
+  nota: Em uma busca, a navegação em loop é dependente da caixa de verificação no diálogo de busca. Se a caixa de verificação busca circular estiver marcada, então a repetição de uma busca com NVDA+f3/NVDA+SHIFT+f3 vai ocorrer de forma circular. Se estiver desmarcada, o comportamento padrão será adotado.
  3. Para ativar ou desativar o loop de tela, utilize o comando **nvda+h**.
   Nota: Pode alterar o comando predefinido no diálogo Definir comandos do NVDA na categoria Modo de navegação.
   
@@ -24,6 +25,6 @@ No caso de encontrar um bug, pode mencionar no Twitter em [HamadaTrichine](https
 
 Aqui está a a lista de todos os colaboradores:
 
-* Marlon Sousa (Correções ortográficas, traduções, compatibilidade com NVDA 2019.3 e 2021.1)
+* Marlon Sousa (Correções ortográficas, traduções, compatibilidade com NVDA 2019.3, 2021.1 e 2023.1, correções de bugs)
 
 [1]: https://github.com/hamadatrichine/nvda-screen-wrapping/releases/latest

--- a/addon/doc/pt_PT/readme.md
+++ b/addon/doc/pt_PT/readme.md
@@ -12,7 +12,8 @@ Se estivermos a usar as teclas de navegação rápida no sentido inverso, ou sej
 A utilização deste extra é simples, basta seguir os seguintes passos:
 
  1. Instale o extra;
- 2. Navegue pelas páginas Web, usando  as teclas de navegação rápida;
+ 2. Navegue pelas páginas Web, usando  as teclas de navegação rápida, ou tente realizar uma busca usando NVDA+CTRL+f (comando padrão);
+  nota: Em uma busca, a navegação em loop é dependente da caixa de verificação no diálogo de busca. Se a caixa de verificação busca circular estiver marcada, então a repetição de uma busca com NVDA+f3/NVDA+SHIFT+f3 vai ocorrer de forma circular. Se estiver desmarcada, o comportamento padrão será adotado.
  3. Pode activar ou desactivar  o loop de ecrã utilizando **nvda+h**.
   Nota: Pode alterar o comando predefinido no diálogo Definir comandos do NVDA na categoria Modo de navegação.
   
@@ -24,6 +25,6 @@ No caso de encontrar um bug, pode mencionar no Twitter em [HamadaTrichine](https
 
 Aqui está a a lista de todos os colaboradores:
 
-* Marlon Sousa (Correções ortográficas, traduções, compatibilidade com NVDA 2019.3 e 2021.1)
+* Marlon Sousa (Correções ortográficas, traduções, compatibilidade com NVDA 2019.3, 2021.1 e 2023.1, correções de bugs)
 
 [1]: https://github.com/hamadatrichine/nvda-screen-wrapping/releases/latest

--- a/addon/globalPlugins/screenWrapping/wrappingAlerts.py
+++ b/addon/globalPlugins/screenWrapping/wrappingAlerts.py
@@ -6,6 +6,8 @@ from speech import cancelSpeech
 from ui import message
 from tones import beep
 
+import addonHandler
+addonHandler.initTranslation()
 
 DIRECTION_NEXT = "next"
 DIRECTION_PREV = "previous"
@@ -28,11 +30,11 @@ def alertWrp(direction):
 def alertToggleFunctionality(state):
 	if state:
 		message(
-			# Translators: Text spoken when screen rapping is turned off.
+			# Translators: Text spoken when screen wrapping is turned off.
 			_("Screen wrapping off."))
 		playBeep(100,150)
 	else:
 		message(
-			# Translators: Text spoken when screen rapping is turned on.
+			# Translators: Text spoken when screen wrapping is turned on.
 			_("Screen wrapping on."))
 		playBeep(400,150)

--- a/addon/globalPlugins/screenWrapping/wrappingFind.py
+++ b/addon/globalPlugins/screenWrapping/wrappingFind.py
@@ -8,14 +8,17 @@ import controlTypes
 from core import callLater
 from cursorManager import CursorManager
 from gui import guiHelper, messageBox
+import addonHandler
+addonHandler.initTranslation()
 from gui.contextHelp import ContextHelpMixin
 from . import wrappingAlerts
+
 
 
 class CustomFindDialog(ContextHelpMixin, wx.Dialog, ):
 	helpId = "SearchingForText"
 	def __init__(self, parent, cursorManager, text, isCaseSensitive, reverse=False):
-			# Translators: the title of the find dialog
+		# Translators: the title of the find dialog
 		super().__init__(parent=parent, title=_("Find"))
 		self.currentCursorManager = cursorManager
 		self.reverse = reverse

--- a/addon/globalPlugins/screenWrapping/wrappingQuickNav.py
+++ b/addon/globalPlugins/screenWrapping/wrappingQuickNav.py
@@ -9,6 +9,9 @@ from speech import cancelSpeech
 from tones import beep
 from . import wrappingAlerts
 
+import addonHandler
+addonHandler.initTranslation()
+
 
 def getCurrentPos(treeInterceptor):
 	posDelta = treeInterceptor.makeTextInfo(textInfos.POSITION_FIRST)

--- a/addon/locale/pt_BR/LC_MESSAGES/nvda.po
+++ b/addon/locale/pt_BR/LC_MESSAGES/nvda.po
@@ -2,68 +2,113 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ScreenRapping\n"
 "Report-Msgid-Bugs-To: nvda-translations@groups.io\n"
-"POT-Creation-Date: 2020-06-02 09:13-0300\n"
-"PO-Revision-Date: 2020-06-02 09:34-0300\n"
+"POT-Creation-Date: 2023-04-01 23:00-0300\n"
+"PO-Revision-Date: 2023-04-01 23:14-0300\n"
 "Last-Translator: Ângelo Miguel Abrantes <ampa4374@gmail.com>\n"
 "Language-Team: Equipa Portuguesa do NVDA <ampa4374@gmail.com; rui."
 "fontes@tiflotecnia.com>\n"
-"Language: pt\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3.1\n"
-"X-Poedit-Basepath: ../../..\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.2.2\n"
+"X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#. Text to translate
-#. Translators: Text spoken when screen wrapping to top.
-#: addon\globalPlugins\screenWrapping\__init__.py:26
-msgid "wrapping to top"
-msgstr "Voltando ao início"
-
-#. Translators: Text spoken when screen wrapping to bottom.
-#: addon\globalPlugins\screenWrapping\__init__.py:28
-msgid "wrapping to bottom"
-msgstr "Voltando ao fim"
-
-#. translators: Text spoken when the type of nav items does not exist in the page.
-#: addon\globalPlugins\screenWrapping\__init__.py:48
-#, fuzzy
-#| msgid "No {} in this page."
-msgid "No {} in this page"
-msgstr "Sem {} nesta página."
-
-#. Translators: a message when a particular quick nav command is not supported in the current document.
-#: addon\globalPlugins\screenWrapping\__init__.py:85
-msgid "Not supported in this document"
-msgstr "Não suportado neste documento"
-
 #. Translators: A discription for the toggleScreenWrapping script.
-#: addon\globalPlugins\screenWrapping\__init__.py:114
+#: addon\globalPlugins\screenWrapping\__init__.py:46
 msgid "Activates and deactivates the screen wrapping feature."
 msgstr "Ativar ou desativar o loop de tela"
 
-#. Translators: Text spoken when screen rapping is turned off.
-#: addon\globalPlugins\screenWrapping\__init__.py:125
+#. Translators: Text spoken when screen wrapping to bottom.
+#: addon\globalPlugins\screenWrapping\wrappingAlerts.py:23
+msgid "wrapping to bottom"
+msgstr "Voltando ao fim"
+
+#. Translators: Text spoken when screen wrapping to top.
+#: addon\globalPlugins\screenWrapping\wrappingAlerts.py:27
+msgid "wrapping to top"
+msgstr "Voltando ao início"
+
+#. Translators: Text spoken when screen wrapping is turned off.
+#: addon\globalPlugins\screenWrapping\wrappingAlerts.py:34
 msgid "Screen wrapping off."
 msgstr "Loop de tela desativado"
 
-#. Translators: Text spoken when screen rapping is turned on.
-#: addon\globalPlugins\screenWrapping\__init__.py:133
+#. Translators: Text spoken when screen wrapping is turned on.
+#: addon\globalPlugins\screenWrapping\wrappingAlerts.py:39
 msgid "Screen wrapping on."
 msgstr "Loop de tela ativado"
 
+#. Translators: the title of the find dialog
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:21
+msgid "Find"
+msgstr "Buscar"
+
+#. Translators: a label for the edit text box where you type your search query
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:28
+msgid "Type the text you wish to find"
+msgstr "Digite o texto a ser buscado"
+
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:30
+msgid "Case &sensitive"
+msgstr "Distinguir &maiúsculas de minúsculas"
+
+#. Translators: An option in the find dialog to allow wrapping on search.
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:33
+msgid "&Wrap around"
+msgstr "&Busca circular"
+
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:78
+#, python-format
+msgid "text \"%s\" not found"
+msgstr "Texto \"%s\" não encontrado"
+
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:78
+msgid "Find Error"
+msgstr "Erro de busca"
+
+#. Translators: a message when a particular quick nav command is not supported in the current document.
+#: addon\globalPlugins\screenWrapping\wrappingQuickNav.py:66
+msgid "Not supported in this document"
+msgstr "Não suportado neste documento"
+
+#. Translators: The name of the addon.
+#: addon\globalPlugins\screenWrapping\wrappingSettingsGui.py:10
+msgid "Screen Wrapping"
+msgstr "Loop de tela"
+
+#. Translators: Text for the check box in the settings that turns on or off the beeps when wrapping.
+#: addon\globalPlugins\screenWrapping\wrappingSettingsGui.py:15
+msgid "&Play a beep when wrapping"
+msgstr "&Tocar um beep ao navegar em loop"
+
+#. Translators: Text for the button in the settings that copys the donation E-mail to the clipboard.
+#: addon\globalPlugins\screenWrapping\wrappingSettingsGui.py:18
+msgid "&Copy PayPal donation E-mail to clipboard"
+msgstr "&Copiar e-mail de doação do Paypal para a área de transferência"
+
 #. Add-on summary, usually the user visible name of the addon.
-#. Translators: Summary for this add-on to be shown on installation and add-on information.
-#: buildVars.py:17
+#. Translators: Summary for this add-on
+#. to be shown on installation and add-on information found in Add-ons Manager.
+#: buildVars.py:23
 msgid "screen wrapping for nvda"
 msgstr "Loop de tela para NVDA"
 
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
-#: buildVars.py:20
+#: buildVars.py:26
+#, fuzzy
+#| msgid ""
+#| "This addon brings the screen wrapping feature to nvda.\n"
+#| "\tWhen you press quick navigation keys such as h, b, f and others, you "
+#| "will be placed on the next element regardless of your current position on "
+#| "a webpage.\n"
+#| "\tIf elements are not found below your position, you will be placed at "
+#| "the first element of the requested type available from the beginning of "
+#| "the page and virseversa when you are searching upwards."
 msgid ""
 "This addon brings the screen wrapping feature to nvda.\n"
 "\tWhen you press quick navigation keys such as h, b, f and others, you will "
@@ -71,7 +116,8 @@ msgid ""
 "webpage.\n"
 "\tIf elements are not found below your position, you will be placed at the "
 "first element of the requested type available from the beginning of the page "
-"and virseversa when you are searching upwards."
+"and vice versa when you are searching upwards. this also extends to the find "
+"dialog of nvda."
 msgstr ""
 "Este complemento trás o loop de tela para o NVDA.\n"
 "Quando pressionar as teclas de navegação rápida, tais como h, b, f ou "
@@ -80,6 +126,11 @@ msgstr ""
 "Se o elemento sollicitado não for encontrado abaixo da posição atual, você "
 "será posicionado no primeiro elemento do tipo solicitado no texto. O inverso "
 "acontece se você estiver procurando por elementos na ordem reversa."
+
+#, fuzzy
+#~| msgid "No {} in this page."
+#~ msgid "No {} in this page"
+#~ msgstr "Sem {} nesta página."
 
 #~ msgid "Screen curtain"
 #~ msgstr "Cortina de ecrã"

--- a/addon/locale/pt_PT/LC_MESSAGES/nvda.po
+++ b/addon/locale/pt_PT/LC_MESSAGES/nvda.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ScreenRapping\n"
 "Report-Msgid-Bugs-To: nvda-translations@groups.io\n"
-"POT-Creation-Date: 2020-06-02 09:13-0300\n"
-"PO-Revision-Date: 2020-06-02 09:14-0300\n"
+"POT-Creation-Date: 2023-04-01 23:00-0300\n"
+"PO-Revision-Date: 2023-04-01 23:15-0300\n"
 "Last-Translator: Ângelo Miguel Abrantes <ampa4374@gmail.com>\n"
 "Language-Team: Equipa Portuguesa do NVDA <ampa4374@gmail.com; rui."
 "fontes@tiflotecnia.com>\n"
@@ -11,65 +11,101 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3.1\n"
-"X-Poedit-Basepath: ../../..\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.2.2\n"
+"X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#. Text to translate
-#. Translators: Text spoken when screen wrapping to top.
-#: addon\globalPlugins\screenWrapping\__init__.py:26
-msgid "wrapping to top"
-msgstr "Voltando ao início"
-
-#. Translators: Text spoken when screen wrapping to bottom.
-#: addon\globalPlugins\screenWrapping\__init__.py:28
-msgid "wrapping to bottom"
-msgstr "Voltando ao fim"
-
-#. translators: Text spoken when the type of nav items does not exist in the page.
-#: addon\globalPlugins\screenWrapping\__init__.py:48
-#, fuzzy
-#| msgid "No {} in this page."
-msgid "No {} in this page"
-msgstr "Sem {} nesta página."
-
-#. Translators: a message when a particular quick nav command is not supported in the current document.
-#: addon\globalPlugins\screenWrapping\__init__.py:85
-msgid "Not supported in this document"
-msgstr "Não suportado neste documento"
-
 #. Translators: A discription for the toggleScreenWrapping script.
-#: addon\globalPlugins\screenWrapping\__init__.py:114
+#: addon\globalPlugins\screenWrapping\__init__.py:46
 #, fuzzy
 #| msgid "Activates and deactivates the screen rapping feature."
 msgid "Activates and deactivates the screen wrapping feature."
 msgstr "Activar ou desactivar o loop de ecrã"
 
-#. Translators: Text spoken when screen rapping is turned off.
-#: addon\globalPlugins\screenWrapping\__init__.py:125
+#. Translators: Text spoken when screen wrapping to bottom.
+#: addon\globalPlugins\screenWrapping\wrappingAlerts.py:23
+msgid "wrapping to bottom"
+msgstr "Voltando ao fim"
+
+#. Translators: Text spoken when screen wrapping to top.
+#: addon\globalPlugins\screenWrapping\wrappingAlerts.py:27
+msgid "wrapping to top"
+msgstr "Voltando ao início"
+
+#. Translators: Text spoken when screen wrapping is turned off.
+#: addon\globalPlugins\screenWrapping\wrappingAlerts.py:34
 #, fuzzy
 #| msgid "Screen rapping off."
 msgid "Screen wrapping off."
 msgstr "Loop de ecrã desactivado"
 
-#. Translators: Text spoken when screen rapping is turned on.
-#: addon\globalPlugins\screenWrapping\__init__.py:133
+#. Translators: Text spoken when screen wrapping is turned on.
+#: addon\globalPlugins\screenWrapping\wrappingAlerts.py:39
 #, fuzzy
 #| msgid "Screen rapping on."
 msgid "Screen wrapping on."
 msgstr "Loop de ecrã activado"
 
+#. Translators: the title of the find dialog
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:21
+msgid "Find"
+msgstr "Buscar"
+
+#. Translators: a label for the edit text box where you type your search query
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:28
+msgid "Type the text you wish to find"
+msgstr "Digite o texto a ser buscado"
+
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:30
+msgid "Case &sensitive"
+msgstr "Diferenciar &maiúsculas e minúsculas"
+
+#. Translators: An option in the find dialog to allow wrapping on search.
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:33
+msgid "&Wrap around"
+msgstr "&Busca circular"
+
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:78
+#, python-format
+msgid "text \"%s\" not found"
+msgstr "Texto \"%s\" nào encontrado"
+
+#: addon\globalPlugins\screenWrapping\wrappingFind.py:78
+msgid "Find Error"
+msgstr "Erro de busca"
+
+#. Translators: a message when a particular quick nav command is not supported in the current document.
+#: addon\globalPlugins\screenWrapping\wrappingQuickNav.py:66
+msgid "Not supported in this document"
+msgstr "Não suportado neste documento"
+
+#. Translators: The name of the addon.
+#: addon\globalPlugins\screenWrapping\wrappingSettingsGui.py:10
+msgid "Screen Wrapping"
+msgstr "Loop de ecrã"
+
+#. Translators: Text for the check box in the settings that turns on or off the beeps when wrapping.
+#: addon\globalPlugins\screenWrapping\wrappingSettingsGui.py:15
+msgid "&Play a beep when wrapping"
+msgstr "&Tocar um beep ao navegar em loop"
+
+#. Translators: Text for the button in the settings that copys the donation E-mail to the clipboard.
+#: addon\globalPlugins\screenWrapping\wrappingSettingsGui.py:18
+msgid "&Copy PayPal donation E-mail to clipboard"
+msgstr "&Copiar e-mail de doação do Paypal para a área de transferência"
+
 #. Add-on summary, usually the user visible name of the addon.
-#. Translators: Summary for this add-on to be shown on installation and add-on information.
-#: buildVars.py:17
+#. Translators: Summary for this add-on
+#. to be shown on installation and add-on information found in Add-ons Manager.
+#: buildVars.py:23
 msgid "screen wrapping for nvda"
 msgstr "Loop de ecrã para NVDA"
 
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
-#: buildVars.py:20
+#: buildVars.py:26
 #, fuzzy
 #| msgid ""
 #| "This addon brings the screen wrapping feature to nvda.\n"
@@ -86,7 +122,8 @@ msgid ""
 "webpage.\n"
 "\tIf elements are not found below your position, you will be placed at the "
 "first element of the requested type available from the beginning of the page "
-"and virseversa when you are searching upwards."
+"and vice versa when you are searching upwards. this also extends to the find "
+"dialog of nvda."
 msgstr ""
 "Este extra trás o loop de ecran para o NVDA.\n"
 "Quando pressiona as teclas de navegação rápida, tais como h, b, f ou outras, "
@@ -95,6 +132,11 @@ msgstr ""
 "Se o elemento sollicitado não for encontrado abaixo da posição actual, será "
 "posicionado no primeiro elemento do tipo solicitado no texto. O inverso "
 "acontece se estiver a procurar por elementos na ordem reversa."
+
+#, fuzzy
+#~| msgid "No {} in this page."
+#~ msgid "No {} in this page"
+#~ msgstr "Sem {} nesta página."
 
 #~ msgid "Screen curtain"
 #~ msgstr "Cortina de ecrã"

--- a/buildVars.py
+++ b/buildVars.py
@@ -37,7 +37,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "2020.1",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2022.1",
+	"addon_lastTestedNVDAVersion": "2023.1",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ In the case of any bugs you can mention me on twitter [at HamadaTrichine](https:
 
 Here is the list of all contributors:
 
-* Marlon Sousa (spelling, translations, NVDA 2019.3 and 2021.1 compatibility)
+* Marlon Sousa (spelling, translations, NVDA 2019.3, 2021.1 and 2023.1 compatibility, bug fixes)
 
 * Valentin (Russian translation)
 


### PR DESCRIPTION
In this pr, the following is performed:

1. Documentation and translation files are updated for portuguese language.
2. A bug where translations where not working for most part of the addon is fixed.
3. The compatibility with NVDA 2023.1 is configured.

Please note that you will have to adjust the addon version after merging this pr, the only change in buildvars.py is the one enabling NVDA 2023.1 as last tested version. Plrase note that 2023.1 version was successfully tested.

